### PR TITLE
Wait for DOM to finish loading before altering it

### DIFF
--- a/app/rnames_app/templates/binning_done.html
+++ b/app/rnames_app/templates/binning_done.html
@@ -14,7 +14,7 @@ const show = ty => {
   })
 }
 
-show('berg')
+window.addEventListener('DOMContentLoaded', () => show('berg'));
 </script>
 
 <!-- Beginning of binning -->


### PR DESCRIPTION
Fixes an error on the binning results page.