### PR TITLE
Empty qualifier if user entered own qualifier

### DIFF
--- a/app/frontend/src/components/SnameForm.js
+++ b/app/frontend/src/components/SnameForm.js
@@ -56,6 +56,7 @@ export const SnameForm = ({
 
 		if (!qualifierFromDb) {
 			notify('Choose a qualifier from the dropdown menu.')
+			setQualifier('')
 			return
 		}
 		let nameId, locationId


### PR DESCRIPTION
Empty the Qualifier field when user presses 'Add new structured name', if the qualifier entered was not selected from the dropdown menu (user tried to enter their own qualifier - not allowed).