### PR TITLE
Add UI element to confirm structured name creation in case of a duplicate

### DIFF
--- a/app/frontend/src/components/DuplicateNameDialog.js
+++ b/app/frontend/src/components/DuplicateNameDialog.js
@@ -39,30 +39,6 @@ export const DuplicateNameDialog = ({
 	return (
 		<div>
 			<p>{infoMsg}</p>
-			{duplicateNames.map(v => (
-				<div key={v.id}>
-					<button
-						className={`w3-btn ${id === v.id ? 'w3-green' : ''}`}
-						onClick={() => setId(v.id)}
-					>
-						{`Select "${formatStructuredName(v, { map })}"`}
-					</button>
-					{map[v.reference_id] ? (
-						<span>
-							{'from '}
-							<a
-								target='_blank'
-								rel='noreferrer'
-								href={doiUrl(v.reference_id)}
-							>
-								{map[v.reference_id].title}
-							</a>
-						</span>
-					) : (
-						<></>
-					)}
-				</div>
-			))}
 			<div>
 				<button
 					className={`w3-btn ${
@@ -89,6 +65,30 @@ export const DuplicateNameDialog = ({
 					placeholder='Remarks...'
 				/>
 			</div>
+			{duplicateNames.map(v => (
+				<div key={v.id}>
+					<button
+						className={`w3-btn ${id === v.id ? 'w3-green' : ''}`}
+						onClick={() => setId(v.id)}
+					>
+						{`Select "${formatStructuredName(v, { map })}"`}
+					</button>
+					{map[v.reference_id] ? (
+						<span>
+							{'from '}
+							<a
+								target='_blank'
+								rel='noreferrer'
+								href={doiUrl(v.reference_id)}
+							>
+								{map[v.reference_id].title}
+							</a>
+						</span>
+					) : (
+						<></>
+					)}
+				</div>
+			))}
 			<button
 				className={`w3-btn w3-green ${
 					id !== undefined ? '' : 'w3-disabled'

--- a/app/frontend/src/components/DuplicateNameDialog.js
+++ b/app/frontend/src/components/DuplicateNameDialog.js
@@ -13,7 +13,7 @@ export const DuplicateNameDialog = ({
 	selectHandler,
 	cancelHandler,
 }) => {
-	const [id, setId] = useState(undefined)
+	const [id, setId] = useState(structuredName.id)
 	const [saveWithReference, setSaveWithReference] = useState(true)
 	const [remarks, setRemarks] = useState('')
 	const map = useSelector(selectMap)

--- a/app/frontend/src/components/DuplicateNameDialog.js
+++ b/app/frontend/src/components/DuplicateNameDialog.js
@@ -1,0 +1,108 @@
+import React, { useState } from 'react'
+import { useSelector } from 'react-redux'
+import { formatStructuredName } from '../utilities'
+import { selectMap } from '../store/snames/selectors'
+
+const infoMsg =
+	'You are attempting to create a duplicate structured name. \
+	Please select an existing name to use or confirm that you wish to create a new name.'
+
+export const DuplicateNameDialog = ({
+	structuredName,
+	duplicateNames,
+	selectHandler,
+	cancelHandler,
+}) => {
+	const [id, setId] = useState(undefined)
+	const [saveWithReference, setSaveWithReference] = useState(true)
+	const [remarks, setRemarks] = useState('')
+	const map = useSelector(selectMap)
+
+	const doiUrl = refId => `https://www.doi.org/${map[refId].doi}`
+
+	const submit = () => {
+		if (id === structuredName.id) {
+			const name = {
+				...structuredName,
+				remarks,
+				save_with_reference_id: saveWithReference,
+			}
+
+			selectHandler(name)
+		} else {
+			selectHandler(duplicateNames.find(v => v.id === id))
+		}
+	}
+
+	const checkboxId = 'duplicate-name-dialog-save-with-reference'
+
+	return (
+		<div>
+			<p>{infoMsg}</p>
+			{duplicateNames.map(v => (
+				<div key={v.id}>
+					<button
+						className={`w3-btn ${id === v.id ? 'w3-green' : ''}`}
+						onClick={() => setId(v.id)}
+					>
+						{`Select "${formatStructuredName(v, { map })}"`}
+					</button>
+					{map[v.reference_id] ? (
+						<span>
+							{'from '}
+							<a
+								target='_blank'
+								rel='noreferrer'
+								href={doiUrl(v.reference_id)}
+							>
+								{map[v.reference_id].title}
+							</a>
+						</span>
+					) : (
+						<></>
+					)}
+				</div>
+			))}
+			<div>
+				<button
+					className={`w3-btn ${
+						id === structuredName.id ? 'w3-green' : ''
+					}`}
+					onClick={() => setId(structuredName.id)}
+				>
+					{`Create a new name "${formatStructuredName(
+						structuredName,
+						{ map }
+					)}"`}
+				</button>
+				<input
+					type='checkbox'
+					id={checkboxId}
+					checked={saveWithReference}
+					onChange={() => setSaveWithReference(!saveWithReference)}
+				/>
+				<label htmlFor={checkboxId}>Save with reference id</label>
+				<input
+					type='text'
+					value={remarks}
+					onChange={e => setRemarks(e.target.value)}
+					placeholder='Remarks...'
+				/>
+			</div>
+			<button
+				className={`w3-btn w3-green ${
+					id !== undefined ? '' : 'w3-disabled'
+				}`}
+				onClick={() => submit()}
+			>
+				Ok
+			</button>
+			<button
+				className={'w3-btn w3-grey'}
+				onClick={() => cancelHandler()}
+			>
+				Cancel
+			</button>
+		</div>
+	)
+}

--- a/app/frontend/src/components/SelectedStructuredNames.js
+++ b/app/frontend/src/components/SelectedStructuredNames.js
@@ -8,19 +8,34 @@ import { loadServerData } from '../services/server'
 import { formatStructuredName, parseId } from '../utilities'
 
 export const SelectedStructuredNames = () => {
-	const selection = useSelector(state => {
-		return state.selectedStructuredNames
-			.filter(v => parseId(v).type !== 'structured_name')
-			.map(v => {
+	const [selection, dbNames] = useSelector(state => {
+		const formatName = sname => {
+			const hasReference = state.map[sname.reference_id] !== undefined
+
+			return `${formatStructuredName(sname, state)} (${
+				hasReference ? `${state.map[sname.reference_id].title}, ` : ''
+			}${parseId(sname.id).value})`
+		}
+
+		return [
+			state.selectedStructuredNames
+				.filter(v => parseId(v).type !== 'structured_name')
+				.map(v => {
+					return {
+						id: v,
+						formattedName: formatName(state.map[v]),
+					}
+				}),
+			(loadServerData('structured_names') || []).map(v => {
 				return {
-					id: v,
-					formattedName: formatStructuredName(state.map[v], state),
+					...v,
+					formattedName: formatName(v),
 				}
-			})
+			}),
+		]
 	})
 	const relations = useSelector(v => v.rel)
 	const [search, setSearch] = useState('')
-	const dbNames = loadServerData('structured_names') || []
 	const dispatch = useDispatch()
 	const dataListId = 'selectedStructuredNamesDataList'
 

--- a/app/frontend/src/components/SelectedStructuredNames.js
+++ b/app/frontend/src/components/SelectedStructuredNames.js
@@ -25,7 +25,8 @@ export const SelectedStructuredNames = () => {
 	const dataListId = 'selectedStructuredNamesDataList'
 
 	const handleChange = e => {
-		const result = dbNames.find(v => e.target.value === v.formattedName)
+		const selectedIdNumber = Number(e.target.value)
+		const result = dbNames.find(v => selectedIdNumber === parseId(v.id).value)
 		if (result) {
 			setSearch('')
 			dispatch(selectStructuredName(result.id))
@@ -45,7 +46,7 @@ export const SelectedStructuredNames = () => {
 			<input list={dataListId} value={search} onChange={handleChange} />
 			<datalist id={dataListId}>
 				{dbNames.map(v => (
-					<option key={v.id}>{v.formattedName}</option>
+					<option key={v.id} value={parseId(v.id).value}>{v.formattedName}</option>
 				))}
 			</datalist>
 			{selection.map(v => (

--- a/app/frontend/src/components/SelectedStructuredNames.js
+++ b/app/frontend/src/components/SelectedStructuredNames.js
@@ -25,8 +25,7 @@ export const SelectedStructuredNames = () => {
 	const dataListId = 'selectedStructuredNamesDataList'
 
 	const handleChange = e => {
-		const selectedIdNumber = Number(e.target.value)
-		const result = dbNames.find(v => selectedIdNumber === parseId(v.id).value)
+		const result = dbNames.find(v => e.target.value === v.formattedName)
 		if (result) {
 			setSearch('')
 			dispatch(selectStructuredName(result.id))
@@ -46,7 +45,7 @@ export const SelectedStructuredNames = () => {
 			<input list={dataListId} value={search} onChange={handleChange} />
 			<datalist id={dataListId}>
 				{dbNames.map(v => (
-					<option key={v.id} value={parseId(v.id).value}>{v.formattedName}</option>
+					<option key={v.id}>{v.formattedName}</option>
 				))}
 			</datalist>
 			{selection.map(v => (

--- a/app/frontend/src/components/SnameForm.js
+++ b/app/frontend/src/components/SnameForm.js
@@ -25,6 +25,7 @@ export const SnameForm = ({
 	const [location, setLocation] = useState('')
 	const [qualifier, setQualifier] = useState('')
 	const [notification, setNotification] = useState(null)
+	const [saveWithReference, setSaveWithReference] = useState(false)
 
 	const map = useSelector(selectMap)
 	const names = useSelector(selectAllNames)
@@ -81,6 +82,7 @@ export const SnameForm = ({
 			qualifier_id: qualifierFromDb[0],
 			reference_id: -1,
 			remarks: '',
+			save_with_reference_id: saveWithReference
 		}
 		dispatch(addSname(newSname))
 		dispatch(selectStructuredName(newSname.id))
@@ -115,6 +117,15 @@ export const SnameForm = ({
 				value={location}
 				onChange={e => setLocation(e.target.value)}
 			/>
+			<input
+				type='checkbox'
+				id='structured-name-form-save-with-reference'
+				value={saveWithReference}
+				onClick={e => setSaveWithReference(!saveWithReference)}
+			/>
+			<label htmlFor='structured-name-form-save-with-reference'>
+				Save with reference id
+			</label>
 			<button type='button' onClick={handleSnameAddition}>
 				Save
 			</button>

--- a/app/frontend/src/services/server.js
+++ b/app/frontend/src/services/server.js
@@ -32,7 +32,7 @@ export const initServer = () => {
 		.map(v => {
 			return {
 				...v,
-				id: makeId('db_structured_name'),
+				id: makeId('db_structured_name', v.id),
 				name_id: makeId('db_name', v.name_id),
 				qualifier_id: makeId('db_qualifier', v.qualifier_id),
 				reference_id: makeId('db_reference', v.reference_id),


### PR DESCRIPTION
Contains the following changes
* Adds an option to explicitly save a new structured name with reference
* Adds a UI element when attempting to save a duplicate name with option to instead select an existing name
* Fixes a bug with initializing database structured name data
* Changes structured name selector to deal with duplicate names