### PR TITLE
Change the References heading to Reference

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -56,7 +56,7 @@ const App = () => {
 	return (
 		<>
 			<div>
-				<h2>References</h2>
+				<h2>Referenc</h2>
 				{state.ref.length === 0 ? (
 					<ReferenceForm
 						{...{

--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -56,7 +56,7 @@ const App = () => {
 	return (
 		<>
 			<div>
-				<h2>Referenc</h2>
+				<h2>Reference</h2>
 				{state.ref.length === 0 ? (
 					<ReferenceForm
 						{...{


### PR DESCRIPTION
The References heading has been changed to Reference because it is possible to add only one reference at a time