### PR TITLE
Prevent adding duplicate refs to db

### DIFF
--- a/app/frontend/src/components/DoiForm.js
+++ b/app/frontend/src/components/DoiForm.js
@@ -33,10 +33,7 @@ export const DoiForm = ({
 	const doiSubmit = async e => {
 		e.preventDefault()
 		if (!doiFormIsValid(doi, notify)) return
-		if (
-			findDuplicateDois(doi).length !== 0 ||
-			findDuplicateLinks(doi).length !== 0
-		) {
+		if (findDuplicateDois(doi)) {
 			notify('An existing reference is using the same doi.')
 			return
 		}

--- a/app/frontend/src/components/ReferenceForm.js
+++ b/app/frontend/src/components/ReferenceForm.js
@@ -101,10 +101,19 @@ export const ReferenceForm = ({
 			return
 		}
 
-		if (findDuplicateDois(doi) || findDuplicateDois(link)) {
+		if (findDuplicateDois(doi)) {
 			addErrorMessage(
 				'An existing reference is using the same doi.',
 				'doi'
+			)
+			showErrorMsgs()
+			return
+		}
+
+		if (findDuplicateDois(link)) {
+			addErrorMessage(
+				'An existing reference is using the same permanent link.',
+				'link'
 			)
 			showErrorMsgs()
 			return

--- a/app/frontend/src/components/ReferenceForm.js
+++ b/app/frontend/src/components/ReferenceForm.js
@@ -103,7 +103,12 @@ export const ReferenceForm = ({
 
 		if (findDuplicateDois(doi)) {
 			addErrorMessage(
-				'An existing reference is using the same doi.',
+				<>
+					An existing reference is using the same doi: &nbsp;
+					<a
+						href={`https://www.doi.org/${doi}`}
+					>{`https://www.doi.org/${doi}`}</a>
+				</>,
 				'doi'
 			)
 			showErrorMsgs()

--- a/app/frontend/src/components/ReferenceForm.js
+++ b/app/frontend/src/components/ReferenceForm.js
@@ -12,7 +12,7 @@ export const ReferenceForm = ({
 	showNewReferenceForm,
 	reference = undefined,
 	isQueried = false,
-	setFocusOnSnameButton
+	setFocusOnSnameButton,
 }) => {
 	const dispatch = useDispatch()
 
@@ -95,18 +95,17 @@ export const ReferenceForm = ({
 			link,
 			addErrorMessage
 		)
-		if (
-			findDuplicateDois(doi).length !== 0 ||
-			findDuplicateLinks(doi).length !== 0
-		) {
+
+		if (!valid) {
+			showErrorMsgs()
+			return
+		}
+
+		if (findDuplicateDois(doi) || findDuplicateDois(link)) {
 			addErrorMessage(
 				'An existing reference is using the same doi.',
 				'doi'
 			)
-			showErrorMsgs()
-			return
-		}
-		if (!valid) {
 			showErrorMsgs()
 			return
 		}
@@ -168,7 +167,9 @@ export const ReferenceForm = ({
 						setField={setLink}
 						notification={formFieldNotification.link}
 					/>
-					<button type='submit' onClick={setFocusOnSnameButton}>Save reference</button>
+					<button type='submit' onClick={setFocusOnSnameButton}>
+						Save reference
+					</button>
 					{reference ? (
 						<>
 							<br />


### PR DESCRIPTION
Checks whether a reference with the same **doi url** or doi is found from the database. Takes into account that doi url can use different resolvers.  