### PR TITLE
Tests for Submit.js and SelectedStructuredNames.js

### DIFF
--- a/app/frontend/src/components/Submit.js
+++ b/app/frontend/src/components/Submit.js
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import axios from 'axios'
 import { updateRefForSubmission } from '../validations'
+import { Notification } from './Notification'
 
 export const Submit = () => {
 	const data = useSelector(v => {
@@ -12,17 +13,32 @@ export const Submit = () => {
 			names: v.names,
 		}
 	})
+	const [notification, setNotification] = useState(null)
+
+	useEffect(() => {
+		if (!notification) return
+		setTimeout(() => {
+			setNotification(null)
+		}, 7000)
+	}, [notification])
+
+	const notify = (message, type = 'error') => {
+		setNotification({ message, type })
+	}
 
 	const submit = async () => {
+		if (!data.reference) {
+			notify('Please add reference before submitting')
+			return
+		}
+
 		if (data.reference && data.reference.edit) {
-			console.log(
-				'Please save changes made in reference before submitting'
-			)
+			notify('Please save changes made in reference before submitting')
 			return
 		}
 
 		if (data.relations.length === 0) {
-			console.log(
+			notify(
 				'Please add structured names and relations before submitting'
 			)
 			return
@@ -72,5 +88,10 @@ export const Submit = () => {
 			.catch(err => console.log(err))
 	}
 
-	return <button onClick={e => submit()}>Submit</button>
+	return (
+		<>
+			<Notification notification={notification} />
+			<button onClick={e => submit()}>Submit</button>
+		</>
+	)
 }

--- a/app/frontend/src/components/__tests__/ReferenceForm.test.js
+++ b/app/frontend/src/components/__tests__/ReferenceForm.test.js
@@ -18,6 +18,7 @@ jest.mock('../../utilities.js')
 describe('When no reference information provided, ReferenceForm', () => {
 	let store
 	beforeEach(() => {
+		jest.clearAllMocks()
 		store = mockStore({
 			ref: refReducer,
 		})
@@ -61,8 +62,10 @@ describe('When no reference information provided, ReferenceForm', () => {
 		await screen.findByDisplayValue('Úna C. Farrell')
 	})
 
-	test('creats a new reference on save', async () => {
-		utilities.findDuplicateDois.mockImplementationOnce(value => false)
+	test('creates a new reference on save', async () => {
+		utilities.findDuplicateDois
+			.mockImplementationOnce(value => false)
+			.mockImplementationOnce(value => false)
 		const inputFields = screen.getAllByRole('textbox')
 		const saveReferenceBtn = screen.getByRole('button', { name: /save/i })
 		userEvent.type(
@@ -85,16 +88,23 @@ describe('When no reference information provided, ReferenceForm', () => {
 	})
 
 	test('does not print error msg if no doi or link duplicates found', async () => {
-		utilities.findDuplicateDois.mockImplementationOnce(value => false)
+		utilities.findDuplicateDois
+			.mockImplementationOnce(value => false)
+			.mockImplementationOnce(value => false)
+		const inputFields = screen.getAllByRole('textbox')
 		const saveReferenceBtn = screen.getByRole('button', { name: /save/i })
+		userEvent.type(
+			inputFields[2],
+			"Beyond Beecher's Trilobite Bed: Widespread pyritization of soft tissues in the Late Ordovician Taconic foreland basin"
+		)
 		userEvent.click(saveReferenceBtn)
 		const notification = await screen.queryByText(
-			'An existing reference is using the same doi.'
+			/An existing reference is using the same doi/i
 		)
 		expect(notification).not.toBeInTheDocument()
 	})
 
-	test('prints error msg if doi or link duplicates found', async () => {
+	test('prints error msg if doi duplicates found', async () => {
 		utilities.findDuplicateDois.mockImplementationOnce(value => true)
 		const inputFields = screen.getAllByRole('textbox')
 		userEvent.type(
@@ -103,10 +113,23 @@ describe('When no reference information provided, ReferenceForm', () => {
 		)
 		const saveReferenceBtn = screen.getByRole('button', { name: /save/i })
 		userEvent.click(saveReferenceBtn)
-		const notification = await screen.queryByText(
-			'An existing reference is using the same doi.'
+		await screen.findByText(/An existing reference is using the same doi/i)
+	})
+
+	test('prints error msg if link duplicates found', async () => {
+		utilities.findDuplicateDois
+			.mockImplementationOnce(value => false)
+			.mockImplementationOnce(value => true)
+		const inputFields = screen.getAllByRole('textbox')
+		userEvent.type(
+			inputFields[2],
+			"Beyond Beecher's Trilobite Bed: Widespread pyritization of soft tissues in the Late Ordovician Taconic foreland basin"
 		)
-		expect(notification).toBeInTheDocument()
+		const saveReferenceBtn = screen.getByRole('button', { name: /save/i })
+		userEvent.click(saveReferenceBtn)
+		await screen.findByText(
+			/An existing reference is using the same permanent link/i
+		)
 	})
 })
 
@@ -151,7 +174,9 @@ describe('When user is editing an existing reference, ReferenceForm', () => {
 	})
 
 	test('does not create a new reference on save', async () => {
-		utilities.findDuplicateDois.mockImplementationOnce(value => false)
+		utilities.findDuplicateDois
+			.mockImplementationOnce(value => false)
+			.mockImplementationOnce(value => false)
 		const inputFields = screen.getAllByRole('textbox')
 		const saveReferenceBtn = screen.getByRole('button', {
 			name: /save/i,
@@ -167,7 +192,9 @@ describe('When user is editing an existing reference, ReferenceForm', () => {
 	})
 
 	test('updates an existing reference on save', async () => {
-		utilities.findDuplicateDois.mockImplementationOnce(value => false)
+		utilities.findDuplicateDois
+			.mockImplementationOnce(value => false)
+			.mockImplementationOnce(value => false)
 		const inputFields = screen.getAllByRole('textbox')
 		const saveReferenceBtn = screen.getByRole('button', { name: /save/i })
 		userEvent.clear(inputFields[0])
@@ -216,7 +243,9 @@ describe('When user has found reference information via doi search, ReferenceFor
 			</Provider>
 		)
 		axios.get.mockImplementationOnce(() => Promise.resolve(data))
-		utilities.findDuplicateDois.mockImplementationOnce(value => false)
+		utilities.findDuplicateDois
+			.mockImplementationOnce(value => false)
+			.mockImplementationOnce(value => false)
 	})
 
 	test('has one button for saving the reference', async () => {
@@ -264,7 +293,9 @@ describe('When user has found reference information via doi search, ReferenceFor
 		userEvent.type(doiInputField, '10.1002/spp2.1267')
 		userEvent.click(getButton)
 		await waitFor(() => {
-			utilities.findDuplicateDois.mockImplementationOnce(value => false)
+			utilities.findDuplicateDois
+				.mockImplementationOnce(value => false)
+				.mockImplementationOnce(value => false)
 			const saveReferenceBtn = screen.getByRole('button', {
 				name: /save/i,
 			})
@@ -296,7 +327,10 @@ describe('ReferenceForm validates input and', () => {
 				<button id='sname-button'>Add new structured name</button>
 			</Provider>
 		)
-		utilities.findDuplicateDois.mockImplementationOnce(value => false)
+		jest.clearAllMocks()
+		utilities.findDuplicateDois
+			.mockImplementationOnce(value => false)
+			.mockImplementationOnce(value => false)
 	})
 
 	test('does not print error msg if user provides correct data for reference', async () => {

--- a/app/frontend/src/components/__tests__/SelectedStructuredNames.test.js
+++ b/app/frontend/src/components/__tests__/SelectedStructuredNames.test.js
@@ -1,0 +1,275 @@
+import React from 'react'
+import { createStore, combineReducers, applyMiddleware } from 'redux'
+import thunk from 'redux-thunk'
+import { expect, test, beforeEach, describe, jest } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import userEvent from '@testing-library/user-event'
+import configureStore from 'redux-mock-store'
+import { SelectedStructuredNames } from '../SelectedStructuredNames'
+import { Provider } from 'react-redux'
+import { refReducer } from '../../store/references/reducers'
+import { snameReducer } from '../../store/snames/reducers'
+import { relReducer } from '../../store/relations/reducers'
+import { selectedStructuredNamesReducer } from '../../store/selected_structured_names/reducers'
+import { addRel } from '../../store/relations/actions'
+import { selectStructuredName } from '../../store/selected_structured_names/actions'
+import { makeId } from '../../utilities'
+import { mapReducer } from '../../store/map/reducers'
+import { nameReducer } from '../../store/names/reducers'
+import * as server from '../../services/server'
+import { initMapvalues } from '../../store/map/actions'
+
+const mockStore = configureStore([])
+jest.spyOn(server, 'loadServerData')
+
+const reference = {
+	firstAuthor: 'Úna C. Farrell',
+	year: 2009,
+	title: "Beyond Beecher's Trilobite Bed: Widespread pyritization of soft tissues in the Late Ordovician Taconic foreland basin",
+	doi: '10.1130/g30177a.1',
+	link: 'https://pubs.geoscienceworld.org/gsa/geology/article-abstract/37/10/907/103864/Beyond-Beecher-s-Trilobite-Bed-Widespread',
+	exists: false,
+	queried: true,
+	edit: false,
+	id: '{"type":"db_reference","value":30590}',
+}
+
+const dbStructuredName1 = {
+	id: '{"type":"db_structured_name","value":1296}',
+	name_id: '{"type":"db_name","value":1126}',
+	location_id: '{"type":"db_location","value":70}',
+	qualifier_id: '{"type":"db_qualifier","value":7}',
+	reference_id: '{"type":"db_reference","value":0}',
+	remarks: null,
+	formattedName: 'Yeoman / Formation / Saskatchewan',
+}
+
+const dbSname1Formatted = 'Yeoman / Formation / Saskatchewan (1296)'
+
+const dbStructuredName2 = {
+	id: '{"type":"db_structured_name","value":5031}',
+	location_id: '{"type":"db_location","value":1}',
+	name_id: '{"type":"db_name","value":4644}',
+	qualifier_id: '{"type":"db_qualifier","value":5}',
+	reference_id: '{"type":"db_reference","value":0}',
+	remarks: null,
+	formattedName: 'Aalenian / Stage / Global',
+}
+
+const relation = {
+	id: makeId('relation'),
+	name1: dbStructuredName1.id,
+	name2: makeId('structured_name'),
+	reference_id: -1,
+}
+
+const initialMapState = {
+	[dbStructuredName1.id]: {
+		...dbStructuredName1,
+	},
+	[dbStructuredName1.name_id]: {
+		id: [dbStructuredName1.name_id],
+		name: 'Yeoman',
+	},
+	[dbStructuredName1.location_id]: {
+		id: [dbStructuredName1.location_id],
+		name: 'Saskatchewan',
+	},
+	[dbStructuredName1.qualifier_id]: {
+		id: [dbStructuredName1.qualifier_id],
+		level: 2,
+		qualifier_name_id: '{"type":"db_qualifier_name","value":7}',
+		stratigraphic_qualifier_id: 2,
+	},
+	'{"type":"db_qualifier_name","value":7}': {
+		id: '{"type":"db_qualifier_name","value":7}',
+		name: 'Formation',
+	},
+	[dbStructuredName2.id]: {
+		...dbStructuredName2,
+	},
+	[dbStructuredName2.name_id]: {
+		id: [dbStructuredName2.name_id],
+		name: 'Aalenian',
+	},
+	[dbStructuredName2.location_id]: {
+		id: [dbStructuredName2.location_id],
+		name: 'Global',
+	},
+	[dbStructuredName2.qualifier_id]: {
+		id: [dbStructuredName2.qualifier_id],
+		level: 5,
+		qualifier_name_id: '{"type":"db_qualifier_name","value":5}',
+		stratigraphic_qualifier_id: 1,
+	},
+	'{"type":"db_qualifier_name","value":5}': {
+		id: '{"type":"db_qualifier_name","value":5}',
+		name: 'Stage',
+	},
+}
+
+describe('When no existing structured names selected', () => {
+	let store
+	beforeEach(() => {
+		jest.clearAllMocks()
+		store = mockStore({
+			map: mapReducer(initialMapState, { type: 'INIT' }),
+			rel: relReducer([], { type: 'INIT', rel: {} }),
+			selectedStructuredNames: selectedStructuredNamesReducer([], {
+				type: 'INIT',
+				structured_name_id: 9080,
+			}),
+		})
+		store.dispatch = jest.fn()
+		server.loadServerData.mockImplementation(k => [
+			dbStructuredName1,
+			dbStructuredName2,
+		])
+		render(
+			<Provider store={store}>
+				<SelectedStructuredNames />
+			</Provider>
+		)
+	})
+
+	test('has text "Select existing name"', () => {
+		const label = screen.getByText(/Select existing name/i)
+		expect(label).toBeInTheDocument()
+	})
+
+	test('does not show "deselect" button', () => {
+		const deselectButton = screen.queryByRole('button', {
+			name: /Deselect/i,
+		})
+		expect(deselectButton).not.toBeInTheDocument()
+	})
+
+	test('has an input field for search', () => {
+		const inputField = screen.getByRole('combobox')
+		expect(inputField).toBeInTheDocument()
+	})
+
+	test('allows to select sname options from database', () => {
+		const yeomanSname = screen.getByText(
+			/Yeoman \/ Formation \/ Saskatchewan/i
+		)
+		const aalenianSname = screen.getByText(/Aalenian \/ Stage \/ Global/i)
+		expect(yeomanSname).toBeInTheDocument()
+		expect(aalenianSname).toBeInTheDocument()
+	})
+
+	test('reflects the user input', async () => {
+		const inputField = screen.getByRole('combobox')
+		userEvent.type(inputField, 'Upper Ord')
+		await screen.findByDisplayValue('Upper Ord')
+	})
+
+	test('allows to select an existing structured name', async () => {
+		const inputField = screen.getByRole('combobox')
+		userEvent.paste(inputField, dbSname1Formatted)
+		expect(store.dispatch).toHaveBeenCalledTimes(1)
+		expect(store.dispatch).toHaveBeenCalledWith({
+			type: 'SELECT_STRUCTURED_NAME',
+			structured_name_id: dbStructuredName1.id,
+		})
+	})
+})
+
+/** This describe block uses real store instead of mocked one
+ * to check that deselcct works as expected */
+describe('When some existing structured names have been selected', () => {
+	let store
+	beforeEach(() => {
+		jest.clearAllMocks()
+		store = createStore(
+			combineReducers({
+				ref: refReducer,
+				sname: snameReducer,
+				rel: relReducer,
+				map: mapReducer,
+				names: nameReducer,
+				selectedStructuredNames: selectedStructuredNamesReducer,
+			}),
+			applyMiddleware(thunk)
+		)
+		server.loadServerData.mockImplementation(k => [
+			dbStructuredName1,
+			dbStructuredName2,
+		])
+		store.dispatch(initMapvalues(initialMapState))
+		store.dispatch(selectStructuredName(dbStructuredName1.id))
+		render(
+			<Provider store={store}>
+				<SelectedStructuredNames />
+			</Provider>
+		)
+	})
+
+	test('shows selected sname on the selected snames list', () => {
+		const selection = screen.getAllByText(
+			/Yeoman \/ Formation \/ Saskatchewan/i
+		)
+		expect(selection).toHaveLength(2)
+	})
+
+	test('does not add duplicate selections to the selected snames list', async () => {
+		const inputField = screen.getByRole('combobox')
+		userEvent.paste(inputField, dbSname1Formatted)
+		const selection = await screen.findAllByText(
+			/Yeoman \/ Formation \/ Saskatchewan/i
+		)
+		expect(selection).toHaveLength(2)
+	})
+
+	test('shows "deselect" button', () => {
+		const deselectButtons = screen.getAllByRole('button', {
+			name: /Deselect/i,
+		})
+		expect(deselectButtons).toHaveLength(1)
+	})
+
+	test('allows to deselect the selected structured name', async () => {
+		const deselectButton = screen.getByRole('button', {
+			name: /Deselect/i,
+		})
+		userEvent.click(deselectButton)
+		const selection = await screen.findAllByText(
+			/Yeoman \/ Formation \/ Saskatchewan/i
+		)
+		expect(selection).toHaveLength(1)
+	})
+})
+
+describe('When selected structured names are dependent on relation', () => {
+	let store
+	beforeEach(() => {
+		jest.clearAllMocks()
+		store = mockStore({
+			map: mapReducer(initialMapState, { type: 'INIT' }),
+			rel: relReducer([], addRel(relation)),
+			selectedStructuredNames: selectedStructuredNamesReducer(
+				[],
+				selectStructuredName(dbStructuredName1.id)
+			),
+		})
+		store.dispatch = jest.fn()
+		server.loadServerData.mockImplementation(k => [
+			dbStructuredName1,
+			dbStructuredName2,
+		])
+		render(
+			<Provider store={store}>
+				<SelectedStructuredNames />
+			</Provider>
+		)
+	})
+
+	test('does not allow to deselect the structured name', () => {
+		const deselectButton = screen.getByRole('button', {
+			name: /Deselect/i,
+		})
+		userEvent.click(deselectButton)
+		expect(store.dispatch).not.toHaveBeenCalled()
+	})
+})

--- a/app/frontend/src/components/__tests__/Submit.test.js
+++ b/app/frontend/src/components/__tests__/Submit.test.js
@@ -1,0 +1,221 @@
+import React from 'react'
+import { expect, test, beforeEach, describe, jest } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import userEvent from '@testing-library/user-event'
+import configureStore from 'redux-mock-store'
+import axios from 'axios'
+import { Submit } from '../Submit'
+import { Provider } from 'react-redux'
+import { refReducer } from '../../store/references/reducers'
+import { snameReducer } from '../../store/snames/reducers'
+import { relReducer } from '../../store/relations/reducers'
+import { nameReducer } from '../../store/names/reducers'
+import { addRef } from '../../store/references/actions'
+import { addSname } from '../../store/snames/actions'
+import { addRel } from '../../store/relations/actions'
+import { makeId } from '../../utilities'
+
+jest.mock('axios')
+const mockStore = configureStore([])
+
+const reference = {
+	firstAuthor: 'Úna C. Farrell',
+	year: 2009,
+	title: "Beyond Beecher's Trilobite Bed: Widespread pyritization of soft tissues in the Late Ordovician Taconic foreland basin",
+	doi: '10.1130/g30177a.1',
+	link: 'https://pubs.geoscienceworld.org/gsa/geology/article-abstract/37/10/907/103864/Beyond-Beecher-s-Trilobite-Bed-Widespread',
+	exists: false,
+	queried: true,
+	edit: false,
+	id: makeId('reference'),
+}
+
+const structuredName = {
+	id: makeId('structured_name'),
+	name_id: makeId('db_name'),
+	location_id: makeId('db_location'),
+	qualifier_id: makeId('db_qualifier'),
+	reference_id: -1,
+	remarks: '',
+	save_with_reference_id: true,
+}
+
+const relation = {
+	id: makeId('relation'),
+	name1: structuredName.id,
+	name2: makeId('structured_name'),
+	reference_id: -1,
+}
+
+describe('When no reference provided', () => {
+	let store
+	beforeEach(() => {
+		store = mockStore({
+			ref: refReducer([], { type: 'INIT', ref: {} }),
+			sname: snameReducer([], { type: 'INIT', sname: {} }),
+			rel: relReducer([], { type: 'INIT', rel: {} }),
+			names: nameReducer([], { type: 'INIT' }),
+		})
+		store.dispatch = jest.fn()
+		render(
+			<Provider store={store}>
+				<Submit />
+			</Provider>
+		)
+	})
+	test('has button for submitting information', () => {
+		const submitButton = screen.getByRole('button', { name: /submit/i })
+		expect(submitButton).toBeInTheDocument()
+	})
+
+	test('does not allow to make submit', async () => {
+		const submitButton = screen.getByRole('button', { name: /submit/i })
+		userEvent.click(submitButton)
+		await screen.findByText(/Please add reference before submitting/i)
+	})
+})
+
+describe('When reference provided', () => {
+	let store
+	beforeEach(() => {
+		store = mockStore({
+			ref: refReducer([], addRef(reference)),
+			sname: snameReducer([], { type: 'INIT', sname: {} }),
+			rel: relReducer([], { type: 'INIT', rel: {} }),
+			names: nameReducer([], { type: 'INIT' }),
+		})
+		store.dispatch = jest.fn()
+		render(
+			<Provider store={store}>
+				<Submit />
+			</Provider>
+		)
+	})
+	/**
+	 * Structured names can be chosen from the database (no requirement to add new ones before submitting),
+	 * but it is necessary to choose or add structured names before creating relations.
+	 */
+	test('does not allow to make submit if no relations provided', async () => {
+		const submitButton = screen.getByRole('button', { name: /submit/i })
+		userEvent.click(submitButton)
+		await screen.findByText(
+			/Please add structured names and relations before submitting/i
+		)
+	})
+})
+
+describe('When provided reference is in edit mode', () => {
+	const referenceInEditMode = { ...reference, edit: true }
+	let store
+	beforeEach(() => {
+		store = mockStore({
+			ref: refReducer([], addRef(referenceInEditMode)),
+			sname: snameReducer([], { type: 'INIT', sname: {} }),
+			rel: relReducer([], { type: 'INIT', rel: {} }),
+			names: nameReducer([], { type: 'INIT' }),
+		})
+		store.dispatch = jest.fn()
+		render(
+			<Provider store={store}>
+				<Submit />
+			</Provider>
+		)
+	})
+	test('does not allow to make submit', async () => {
+		const submitButton = screen.getByRole('button', { name: /submit/i })
+		userEvent.click(submitButton)
+		await screen.findByText(
+			/Please save changes made in reference before submitting/i
+		)
+	})
+})
+
+describe('When correct reference information provided', () => {
+	let store
+	beforeEach(() => {
+		store = mockStore({
+			ref: refReducer([], addRef(reference)),
+			sname: snameReducer([], addSname(structuredName)),
+			rel: relReducer([], addRel(relation)),
+			names: nameReducer([], { type: 'INIT' }),
+		})
+		store.dispatch = jest.fn()
+		render(
+			<Provider store={store}>
+				<Submit />
+				<input
+					name='csrfmiddlewaretoken'
+					type='hidden'
+					value='iuWgmrwb9bCCnrgyBplY52qEP8Be1USdh1MPGjpwiwi7OOgLv6SuXC4gwh5IWENn'
+				></input>
+			</Provider>
+		)
+	})
+
+	test('submits data to the server', async () => {
+		const submitButton = screen.getByRole('button', { name: /submit/i })
+		axios.mockImplementationOnce(() => Promise.resolve(true))
+		userEvent.click(submitButton)
+		expect(axios).toHaveBeenCalledTimes(1)
+		expect(axios).toHaveBeenCalledWith({
+			data: {
+				names: [],
+				reference: {
+					doi: '10.1130/g30177a.1',
+					edit: false,
+					exists: false,
+					firstAuthor: 'Úna C. Farrell',
+					id: { type: 'reference', value: expect.anything() },
+					link: 'https://pubs.geoscienceworld.org/gsa/geology/article-abstract/37/10/907/103864/Beyond-Beecher-s-Trilobite-Bed-Widespread',
+					queried: true,
+					title: "Beyond Beecher's Trilobite Bed: Widespread pyritization of soft tissues in the Late Ordovician Taconic foreland basin",
+					year: 2009,
+				},
+				relations: [
+					{
+						id: { type: 'relation', value: expect.anything() },
+						name1: {
+							type: 'structured_name',
+							value: expect.anything(),
+						},
+						name2: {
+							type: 'structured_name',
+							value: expect.anything(),
+						},
+						reference_id: -1,
+					},
+				],
+				structured_names: [
+					{
+						id: {
+							type: 'structured_name',
+							value: expect.anything(),
+						},
+						location_id: {
+							type: 'db_location',
+							value: expect.anything(),
+						},
+						name_id: {
+							type: 'db_name',
+							value: expect.anything(),
+						},
+						qualifier_id: {
+							type: 'db_qualifier',
+							value: expect.anything(),
+						},
+						reference_id: -1,
+						remarks: '',
+						save_with_reference_id: true,
+					},
+				],
+			},
+			headers: {
+				'X-CSRFToken':
+					'iuWgmrwb9bCCnrgyBplY52qEP8Be1USdh1MPGjpwiwi7OOgLv6SuXC4gwh5IWENn',
+			},
+			method: 'POST',
+			url: '/wizard_submit',
+		})
+	})
+})


### PR DESCRIPTION
- Fixes to ReferenceForm.test.js (feature changes in pr 65)
- Tests for Submit.js
- Tests for SelectedStructuredNames.js

**Notice that Submit.js still contains console.log() that will print information about data submitted, this console.log is not related to tests.**