### PR TITLE
Delete unnecessary goBack buttons

### DIFF
--- a/app/rnames_app/templates/help_database_structure.html
+++ b/app/rnames_app/templates/help_database_structure.html
@@ -6,7 +6,6 @@
   <!-- Beginning of RNames help Database Structure-->
   <article>
     <div class="help">
-      <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
       <header class="w3-hide">
         <h2>RNames - Help - Database Structure</h2>
       </header>

--- a/app/rnames_app/templates/help_faq.html
+++ b/app/rnames_app/templates/help_faq.html
@@ -6,7 +6,6 @@
 <!-- Beginning of RNames - Help - FAQ-->
 <article>
     <div class="help faq">
-      <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
             <h2>RNames - Help - FAQ</h2>
         </header>

--- a/app/rnames_app/templates/help_instruction.html
+++ b/app/rnames_app/templates/help_instruction.html
@@ -5,7 +5,6 @@
 <!-- Beginning of RNames help Database Structure-->
 <article>
    <div class="help">
-    <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
     <header class="w3-hide">
          <h2>RNames - Help - Instructions</h2>
       </header>

--- a/app/rnames_app/templates/help_structure_of_binning_algorithm.html
+++ b/app/rnames_app/templates/help_structure_of_binning_algorithm.html
@@ -6,7 +6,6 @@
   <!-- Beginning of RNames help Structure of the Binning Algorithm-->
   <article>
     <div class="help">
-      <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
       <header class="w3-hide">
         <h2>RNames - Help - Structure of the Binning Algorithm</h2>
       </header>

--- a/app/rnames_app/templates/help_wizard.html
+++ b/app/rnames_app/templates/help_wizard.html
@@ -5,7 +5,6 @@
 {% load static %}
 <article>
     <div>
-        <p><button class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
             <h2>RNames - Help - Wizard</h2>
         </header>

--- a/app/rnames_app/templates/location_detail.html
+++ b/app/rnames_app/templates/location_detail.html
@@ -9,7 +9,6 @@
           <a href="{% url 'location-edit' pk=location.pk %}"><span class="fa fa-pencil-square-o"></span></a>
           <a href="{% url 'location-delete' pk=location.pk %}"><span class="fa  fa-trash-o"></span></a>
         {% endif %}
-        <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
             <h2>RNames - Location: {{ location.id }}</h2>
          </header>

--- a/app/rnames_app/templates/location_edit.html
+++ b/app/rnames_app/templates/location_edit.html
@@ -8,7 +8,7 @@
       <h2>Edit Location</h2>
       <form method="POST" class="location-form">{% csrf_token %}
         {{ form.as_p }}
-        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button>
+        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
         <button type="submit" class="w3-button w3-border w3-light-grey" style="width:120px">Submit &nbsp; <i class="fas fa-angle-right"></i></button>      
       </form>
     {% else %}

--- a/app/rnames_app/templates/name_detail.html
+++ b/app/rnames_app/templates/name_detail.html
@@ -9,7 +9,6 @@
           <a href="{% url 'name-edit' pk=name.pk %}"><span class="fa fa-pencil-square-o"></span></a>
           <a href="{% url 'name-delete' pk=name.pk %}"><span class="fa  fa-trash-o"></span></a>
         {% endif %}
-        <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
             <h2>RNames - Name: {{ name.id }}</h2>
          </header>

--- a/app/rnames_app/templates/name_edit.html
+++ b/app/rnames_app/templates/name_edit.html
@@ -11,7 +11,7 @@
       <form method="POST" novalidate>
         {% csrf_token %}
         {% include 'includes/w3c-form.html' with form=form %}
-        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button>
+        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
         <button type="submit" class="w3-button w3-border w3-light-grey" style="width:120px">Submit &nbsp; <i class="fas fa-angle-right"></i></button>      
       </form>
     {% else %}

--- a/app/rnames_app/templates/qualifier_detail.html
+++ b/app/rnames_app/templates/qualifier_detail.html
@@ -9,7 +9,6 @@
         <a href="{% url 'qualifier-edit' pk=qualifier.pk %}"><span class="fa fa-pencil-square-o"></span></a>
         <a href="{% url 'qualifier-delete' pk=qualifier.pk %}"><span class="fa  fa-trash-o"></span></a>
       {% endif %}
-      <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
       <header class="w3-hide">
           <h2>RNames - Qualifier: {{ qualifier.id }}</h2>
        </header>

--- a/app/rnames_app/templates/qualifier_edit.html
+++ b/app/rnames_app/templates/qualifier_edit.html
@@ -8,7 +8,7 @@
       <h2>Edit Qualifier</h2>
       <form method="POST" class="qualifier-form">{% csrf_token %}
         {{ form.as_p }}
-        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button>
+        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
         <button type="submit" class="w3-button w3-border w3-light-grey" style="width:120px">Submit &nbsp; <i class="fas fa-angle-right"></i></button>      
       </form>
     {% else %}

--- a/app/rnames_app/templates/qualifiername_detail.html
+++ b/app/rnames_app/templates/qualifiername_detail.html
@@ -9,7 +9,6 @@
           <a href="{% url 'qualifiername-edit' pk=qualifiername.pk %}"><span class="fa fa-pencil-square-o"></span></a>
           <a href="{% url 'qualifiername-delete' pk=qualifiername.pk %}"><span class="fa  fa-trash-o"></span></a>
         {% endif %}
-        <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
             <h2>RNames - Qualifier Name: {{ qualifiername.id }}</h2>
          </header>

--- a/app/rnames_app/templates/qualifiername_edit.html
+++ b/app/rnames_app/templates/qualifiername_edit.html
@@ -8,7 +8,7 @@
       <h2>Add/Edit Qualifier Name</h2>
       <form method="POST" class="qualifiername-form">{% csrf_token %}
         {{ form.as_p }}
-        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button>
+        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
         <button type="submit" class="w3-button w3-border w3-light-grey" style="width:120px">Submit &nbsp; <i class="fas fa-angle-right"></i></button>      
       </form>
     {% else %}

--- a/app/rnames_app/templates/reference_detail.html
+++ b/app/rnames_app/templates/reference_detail.html
@@ -10,7 +10,6 @@
     <a href="{% url 'reference-edit' pk=reference.pk %}"><span class="fa fa-pencil-square-o"></span></a>
     <a href="{% url 'reference-delete' pk=reference.pk %}"><span class="fa  fa-trash-o"></span></a>
   {% endif %}
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
   <table class="w3-table-all">
     <caption>Reference #{{ reference.id }}</caption>
     <tr>

--- a/app/rnames_app/templates/reference_edit.html
+++ b/app/rnames_app/templates/reference_edit.html
@@ -9,7 +9,7 @@
         <table class="w3-table-all">
           {{ form.as_table }}
         </table>
-        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button>
+        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
         <button type="submit" class="w3-button w3-border w3-light-grey" style="width:120px">Submit &nbsp; <i class="fas fa-angle-right"></i></button>      
       </form>
   </article>

--- a/app/rnames_app/templates/relation_detail.html
+++ b/app/rnames_app/templates/relation_detail.html
@@ -9,7 +9,6 @@
           <a href="{% url 'relation-edit' pk=relation.pk %}"><span class="fa fa-pencil-square-o"></span></a>
           <a href="{% url 'relation-delete' pk=relation.pk %}"><span class="fa  fa-trash-o"></span></a>
         {% endif %}
-        <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
            <h2>RNames - Relation: {{ relation.id }}</h2>
         </header>

--- a/app/rnames_app/templates/relation_edit.html
+++ b/app/rnames_app/templates/relation_edit.html
@@ -15,7 +15,7 @@
         <table class="w3-table-all">
           {{ form.as_table }}
         </table>
-        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button>
+        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
         <button type="submit" class="w3-button w3-border w3-light-grey" style="width:120px">Submit &nbsp; <i class="fas fa-angle-right"></i></button>      
       </form>
 <!--      <form method="POST" class="relation-form">{% csrf_token %}

--- a/app/rnames_app/templates/relation_sql_detail.html
+++ b/app/rnames_app/templates/relation_sql_detail.html
@@ -9,7 +9,6 @@
           <a href="{% url 'relation-edit' pk=relation.pk %}"><span class="fa fa-pencil-square-o"></span></a>
           <a href="{% url 'relation-delete' pk=relation.pk %}"><span class="fa  fa-trash-o"></span></a>
         {% endif %}
-        <p><button class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
            <h2>RNames - Relation: {{ relation.id }}</h2>
         </header>

--- a/app/rnames_app/templates/rnames_app/location_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/location_confirm_delete.html
@@ -9,7 +9,7 @@
       {% csrf_token %}
       <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %} {% endblock %}

--- a/app/rnames_app/templates/rnames_app/name_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/name_confirm_delete.html
@@ -9,7 +9,7 @@
       {% csrf_token %}
       <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %} {% endblock %}

--- a/app/rnames_app/templates/rnames_app/qualifier_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/qualifier_confirm_delete.html
@@ -9,7 +9,7 @@
       {% csrf_token %}
       <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %} {% endblock %}

--- a/app/rnames_app/templates/rnames_app/qualifiername_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/qualifiername_confirm_delete.html
@@ -9,7 +9,7 @@
       {% csrf_token %}
       <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %} {% endblock %}

--- a/app/rnames_app/templates/rnames_app/reference_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/reference_confirm_delete.html
@@ -9,7 +9,7 @@
       {% csrf_token %}
       <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %} {% endblock %}

--- a/app/rnames_app/templates/rnames_app/reference_relation_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/reference_relation_confirm_delete.html
@@ -11,8 +11,8 @@
     {% csrf_token %}
     <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %}
 

--- a/app/rnames_app/templates/rnames_app/relation_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/relation_confirm_delete.html
@@ -11,8 +11,8 @@
     {% csrf_token %}
     <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %}
 

--- a/app/rnames_app/templates/rnames_app/stratigraphicqualifier_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/stratigraphicqualifier_confirm_delete.html
@@ -9,7 +9,7 @@
       {% csrf_token %}
       <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %} {% endblock %}

--- a/app/rnames_app/templates/rnames_app/structuredname_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/structuredname_confirm_delete.html
@@ -11,8 +11,8 @@
     {% csrf_token %}
     <input type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %}
 

--- a/app/rnames_app/templates/rnames_app/timeslice_confirm_delete.html
+++ b/app/rnames_app/templates/rnames_app/timeslice_confirm_delete.html
@@ -9,7 +9,7 @@
       {% csrf_token %}
       <input class="w3-btn w3-red" type="submit" action="" value="Yes, delete." />
   </form>
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-{% else %}
+  <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+  {% else %}
   <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
 {% endif %} {% endblock %}

--- a/app/rnames_app/templates/stratigraphic_qualifier_detail.html
+++ b/app/rnames_app/templates/stratigraphic_qualifier_detail.html
@@ -9,7 +9,6 @@
           <a href="{% url 'stratigraphic-qualifier-edit' pk=stratigraphicqualifier.pk %}"><span class="fa fa-pencil-square-o"></span></a>
           <a href="{% url 'stratigraphic-qualifier-delete' pk=stratigraphicqualifier.pk %}"><span class="fa  fa-trash-o"></span></a>
         {% endif %}
-        <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
            <h2>RNames - Stratigraphic Qualifier: {{ stratigraphicqualifier.id }}</h2>
         </header>

--- a/app/rnames_app/templates/stratigraphic_qualifier_edit.html
+++ b/app/rnames_app/templates/stratigraphic_qualifier_edit.html
@@ -8,7 +8,7 @@
       <h2>Edit Stratigraphic Qualifier</h2>
       <form method="POST" class="stratigraphicqualifier-form">{% csrf_token %}
           {{ form.as_p }}
-          <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button>
+          <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
           <button type="submit" class="w3-button w3-border w3-light-grey" style="width:120px">Submit &nbsp; <i class="fas fa-angle-right"></i></button>      
         </form>
     {% else %}

--- a/app/rnames_app/templates/structuredname_detail.html
+++ b/app/rnames_app/templates/structuredname_detail.html
@@ -10,7 +10,6 @@
   <a href="{% url 'structuredname-edit' pk=structuredname.pk %}"><span class="fa fa-pencil-square-o"></span></a>
   <a href="{% url 'structuredname-delete' pk=structuredname.pk %}"><span class="fa  fa-trash-o"></span></a>
   {% endif %}
-  <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
   <header style="display:none;">
     <h2>RNames - Structured Name: {{ structuredname.id }}</h2>
   </header>

--- a/app/rnames_app/templates/structuredname_edit.html
+++ b/app/rnames_app/templates/structuredname_edit.html
@@ -15,7 +15,7 @@
         <table class="w3-table">
           {{ form.as_table }}
         </table>
-        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button>
+        <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
         <button type="submit" class="w3-button w3-border w3-light-grey" style="width:120px">Submit &nbsp; <i class="fas fa-angle-right"></i></button>      
       </form>
     {% else %}

--- a/app/rnames_app/templates/timeslice_detail.html
+++ b/app/rnames_app/templates/timeslice_detail.html
@@ -9,7 +9,6 @@
           <a class="btn btn-default" href="{% url 'timeslice-edit' pk=timeslice.pk %}"><span class="fa fa-pencil-square-o"></span></a>
           <a class="btn btn-default" href="{% url 'timeslice-delete' pk=timeslice.pk %}"><span class="fa  fa-trash-o"></span></a>
         {% endif %}
-        <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
         <header class="w3-hide">
             <h2>RNames - Time Slice: {{ timeslice.id }}</h2>
          </header>

--- a/app/rnames_app/templates/timeslice_edit.html
+++ b/app/rnames_app/templates/timeslice_edit.html
@@ -10,8 +10,8 @@
           {{ form.as_p }}
           <button type="submit" class="w3-btn w3-green">Save</button>
       </form>
-      <p><button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px"><i class="fas fa-angle-double-left"></i>&nbsp;Go back</button></p>
-    {% else %}
+      <button type="button" class="w3-button w3-border w3-light-grey" onClick="javascript:history.back();" style="width:120px">Cancel</button>
+      {% else %}
       <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
     {% endif %}
 


### PR DESCRIPTION
Delete go back buttons from the help pages because they became useless after the ui update
Delete go back buttons from the detail pages because they work the same way as the browser's go back button and are therefore useless